### PR TITLE
Fix file picker types for expo

### DIFF
--- a/packages/file/src/filePickerTypes.ts
+++ b/packages/file/src/filePickerTypes.ts
@@ -1,4 +1,4 @@
-import { DocumentPickerOptions, DocumentResult } from 'expo-document-picker'
+import { DocumentPickerOptions, DocumentPickerResult as DocumentResult } from 'expo-document-picker'
 import { StackPropsBase } from 'tamagui'
 import { LmButtonProps } from '@tamagui-extras/core'
 

--- a/packages/file/types/filePickerTypes.d.ts
+++ b/packages/file/types/filePickerTypes.d.ts
@@ -1,4 +1,4 @@
-import { DocumentPickerOptions, DocumentResult } from 'expo-document-picker';
+import { DocumentPickerOptions, DocumentPickerResult as DocumentResult } from 'expo-document-picker';
 import { StackPropsBase } from 'tamagui';
 import { LmButtonProps } from '@tamagui-extras/core';
 export type LmFilePickerProps = LmButtonProps & {


### PR DESCRIPTION
It looks like the `expo-document-picker` `DocumentResult` type has been renamed to `DocumentPickerResult` and this type rename hasn't been noticed in a version bump. I've fixed this by renaming the import.